### PR TITLE
switching to stable version of config

### DIFF
--- a/helm-chart/templates/statefulset.yaml
+++ b/helm-chart/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}


### PR DESCRIPTION
The current version assigned to beta 1 is missing StatefulSet as
a kind options. The stable version has it.